### PR TITLE
Trimming and proxying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv
 *.pyc
+gather_to_mongod.env

--- a/flask_jsglue.py
+++ b/flask_jsglue.py
@@ -1,0 +1,62 @@
+from flask import render_template
+from flask import make_response
+from flask import url_for
+from markupsafe import Markup
+import re
+import json
+
+JSGLUE_JS_PATH = '/jsglue.js'
+JSGLUE_NAMESPACE = 'Flask'
+rule_parser = re.compile(r'<(.+?)>')
+splitter = re.compile(r'<.+?>')
+
+
+def get_routes(app):
+    output = []
+    for r in app.url_map.iter_rules():
+        endpoint = r.endpoint
+        if app.config['APPLICATION_ROOT'] == '/' or\
+                not app.config['APPLICATION_ROOT']:
+            rule = r.rule
+        else:
+            rule = '{root}{rule}'.format(
+                root=app.config['APPLICATION_ROOT'],
+                rule=r.rule
+            )
+        rule_args = [x.split(':')[-1] for x in rule_parser.findall(rule)]
+        rule_tr = splitter.split(rule)
+        output.append((endpoint, rule_tr, rule_args))
+    return sorted(output, key=lambda x: len(x[1]), reverse=True)
+
+
+class JSGlue(object):
+    def __init__(self, app=None, **kwargs):
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        self.app = app
+
+        @app.route(JSGLUE_JS_PATH)
+        def serve_js():
+            return make_response(
+                (self.generate_js(), 200, {'Content-Type': 'text/javascript'})
+            )
+
+        @app.context_processor
+        def context_processor():
+            return {'JSGlue': JSGlue}
+
+    def generate_js(self):
+        rules = get_routes(self.app)
+        # .js files are not autoescaped in flask
+        return render_template(
+            'jsglue/js_bridge.js',
+            namespace=JSGLUE_NAMESPACE,
+            rules=json.dumps(rules))
+
+    @staticmethod
+    def include():
+        js_path = url_for('serve_js')
+        return Markup('<script src="%s" type="text/javascript"></script>') % (js_path,)

--- a/gather_to_mongo.py
+++ b/gather_to_mongo.py
@@ -158,6 +158,7 @@ db = client['pkgstatus']
 qat_sets = ["qat", "baseline", "build-as-user"]
 
 # Repair start times
+print("Reparing build start times.")
 for build_info in db.builds.find({'started': {'$exists': False}}, {"_id": "",
     'snap.now': '', 'snap.elapsed': ''}):
     calc_started(build_info)
@@ -165,6 +166,7 @@ for build_info in db.builds.find({'started': {'$exists': False}}, {"_id": "",
     db.builds.update_one({'_id': build_info['_id']}, {'$set': {'started': build_info['started']}})
 
 # Import new data
+print("Importing new data.")
 with open("servers.txt", "r") as f:
     for line in f:
         if line.startswith("#"):
@@ -289,6 +291,7 @@ with open("servers.txt", "r") as f:
         db.servers.update_one({"_id": server_short}, {"$set": server_info})
 
 # Repair pkgnames
+print("Fixing pkgnames.")
 for portids in db.ports.find({'pkgnames': {'$exists': False}}, {"_id": ""}):
     # Fetch here rather than in the loop due to memory explosion
     ports = db.ports.find_one({'_id': portids['_id']},
@@ -298,6 +301,7 @@ for portids in db.ports.find({'pkgnames': {'$exists': False}}, {"_id": ""}):
     db.ports.update_one({'_id': portids['_id']}, {'$set': ports})
 
 # Process new failures
+print("Processing build failures and stats.")
 for portids in db.ports.find({'new': {'$exists': False}},
         {"_id": ""}).sort([('_id', pymongo.ASCENDING)]):
     # This is not done above as it would load several GB of data.

--- a/gather_to_mongo.py
+++ b/gather_to_mongo.py
@@ -7,7 +7,12 @@ import re
 import os
 
 def fetch_data(server, path):
-    url = f"http://{server}{path}"
+    proxy_server = os.getenv("PKGSTATUS_GATHER_PROXY_SERVER")
+
+    if proxy_server:
+        url = f"{proxy_server}/{server.split('.')[0]}{path}"
+    else:
+        url = f"http://{server}{path}"
     print(f"Fetching {url}")
     try:
         response = requests.get(url, timeout=0.5)

--- a/gather_to_mongod.sh
+++ b/gather_to_mongod.sh
@@ -9,6 +9,10 @@ if [ "$1" = "venv" ]; then
 	. venv/bin/activate
 fi
 
+if [ -r gather_to_mongod.env ]; then
+	. gather_to_mongo.env
+fi
+
 while :; do
 	python3 gather_to_mongo.py
 	sleep 60

--- a/pkgstatus.py
+++ b/pkgstatus.py
@@ -54,21 +54,12 @@ def create_app():
                     if field in ports and origin in ports[field]:
                         ports[field][fixed_origin] = ports[field].pop(origin)
 
-    def get_server_map():
-        return {x["_id"]:x for x in list(mongo.db.servers.find({},
-            {'masternames': 0}))}
-
     def get_server(server):
         return mongo.db.servers.find_one({'_id': server}, {'masternames': 0})
 
     @app.route('/')
     def index():
         return builds()
-
-    @app.route('/servers.js')
-    def servers_js():
-        return make_response("var servers = %s;" % (json.dumps(get_server_map())),
-                200, {'Content-Type': 'text/javascript'})
 
     def _get_filter():
         query = {'latest': True}
@@ -117,7 +108,6 @@ def create_app():
     @app.route('/builds')
     def builds():
         results = _builds()
-        results['servers'] = get_server_map()
         return render_template('builds.html', **results)
 
     def _build(buildid):
@@ -135,7 +125,6 @@ def create_app():
     @app.route('/builds/<buildid>')
     def build(buildid):
         results = _build(buildid)
-        results['servers'] = get_server_map()
         return render_template('build.html', **results)
 
     """

--- a/pkgstatus.py
+++ b/pkgstatus.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from flask import Flask, jsonify, render_template, request, make_response, url_for
 from flask_bootstrap import Bootstrap5
+from flask_jsglue import JSGlue
 from flask_pymongo import PyMongo
 from urllib.parse import urlencode
 import flask_pymongo as pymongo
@@ -15,6 +16,7 @@ def create_app():
     app.config['MONGO_URI'] = os.getenv('MONGO_URI', 'mongodb://localhost:27017/pkgstatus')
 
     Bootstrap5(app)
+    jsglue = JSGlue(app)
     mongo = PyMongo(app)
     filter_keys = ['all', 'type', 'setname', 'buildname', 'jailname', 'server']
 

--- a/public/static/pkgstatus.js
+++ b/public/static/pkgstatus.js
@@ -30,9 +30,11 @@ function poudriere_icon() {
 
 function linkpoudrierebuild(build) {
     return '<a target="_new" data-bs-toggle="tooltip" title="Poudriere Build" ' +
-        'href="http://' + servers[build.server].host +
-        '/build.html?mastername=' + build.mastername +
-        '&amp;build=' + build.buildname + '">' + poudriere_icon() + '</a>';
+        'href="' +
+        Flask.url_for('poudriere', {'server': build.server,
+            'uri': 'build.html', 'mastername': build.mastername,
+            'build': build.buildname}) +
+        '">' + poudriere_icon() + '</a>';
 }
 
 function linkbuild(build) {
@@ -80,8 +82,9 @@ function linkserver(build) {
     Flask.url_for('builds', {'server': build.server}) + '">' +
     filter_icon() + '</a>' +
     '<a target="_new" data-bs-toggle="tooltip" title="Poudriere Server" ' +
-    'href="http://' + servers[build.server].host + '/">' +
-    poudriere_icon() + '</a>' +
+        'href="' +
+        Flask.url_for('poudriere', {'server': build.server}) +
+        '">' + poudriere_icon() + '</a>' +
     build.server;
 }
 
@@ -91,9 +94,10 @@ function linkjail(build) {
     Flask.url_for('builds', {'jailname': build.jailname}) + '">' +
     filter_icon() + '</a>' +
     '<a target="_new" data-bs-toggle="tooltip" title="Poudriere Jail" ' +
-    'href="http://' + servers[build.server].host +
-    '/jail.html?mastername=' + build.mastername + '">' + poudriere_icon() +
-    '</a>' + build.jailname;
+        'href="' +
+        Flask.url_for('poudriere', {'server': build.server,
+            'uri': 'jail.html', 'mastername': build.mastername}) +
+        '">' + poudriere_icon() + '</a>' + build.jailname;
 }
 
 function format_duration(duration) {

--- a/public/static/pkgstatus.js
+++ b/public/static/pkgstatus.js
@@ -4,10 +4,6 @@ $(function () {
     });
 });
 
-function flaskUrlFor(endpoint, params) {
-    return '/' + endpoint + '?' + new URLSearchParams(params).toString();
-}
-
 function isNumeric(n) {
     return !isNaN(parseFloat(n)) && isFinite(n);
 }
@@ -29,7 +25,7 @@ function filter_icon() {
 }
 
 function poudriere_icon() {
-    return '<img src="/static/poudriere.png">';
+    return '<img src="' + Flask.url_for('static', {'filename': 'poudriere.png'}) + '">';
 }
 
 function linkpoudrierebuild(build) {
@@ -42,11 +38,11 @@ function linkpoudrierebuild(build) {
 function linkbuild(build) {
     return '<a data-bs-toggle="tooltip" title="All builds matching buildname ' +
         build.buildname + '" href="' +
-        flaskUrlFor('builds', { 'buildname': build.buildname }) + '">' +
+        Flask.url_for('builds', {'buildname': build.buildname}) + '">' +
         filter_icon() + '</a>' +
         linkpoudrierebuild(build) +
         '<a data-bs-toggle="tooltip" title="Build ' + build._id + '" href="' +
-        flaskUrlFor('build', { 'buildid': build._id }).replace('build?buildid=', 'builds/') + '">' +
+        Flask.url_for('build', {'buildid': build._id}) + '">' +
         build.buildname + '</a>';
 }
 
@@ -73,7 +69,7 @@ function linkset(setname) {
     }
 
     return '<a data-bs-toggle="tooltip" title="All builds matching set ' +
-        setname + '" href="' + flaskUrlFor('builds', { 'setname': setname }) +
+        setname + '" href="' + Flask.url_for('builds', {'setname': setname}) +
         '"><span class="bi bi-funnel-fill"></span></a>' +
         link + setname;
 }
@@ -81,7 +77,7 @@ function linkset(setname) {
 function linkserver(build) {
     return '<a data-bs-toggle="tooltip" title="All builds matching server ' +
     build.server + '" href="' +
-    flaskUrlFor('builds', { 'server': build.server }) + '">' +
+    Flask.url_for('builds', {'server': build.server}) + '">' +
     filter_icon() + '</a>' +
     '<a target="_new" data-bs-toggle="tooltip" title="Poudriere Server" ' +
     'href="http://' + servers[build.server].host + '/">' +
@@ -92,7 +88,7 @@ function linkserver(build) {
 function linkjail(build) {
     return '<a data-bs-toggle="tooltip" title="All builds matching jail ' +
     build.jailname + '" href="' +
-    flaskUrlFor('builds', { 'jailname': build.jailname }) + '">' +
+    Flask.url_for('builds', {'jailname': build.jailname}) + '">' +
     filter_icon() + '</a>' +
     '<a target="_new" data-bs-toggle="tooltip" title="Poudriere Jail" ' +
     'href="http://' + servers[build.server].host +
@@ -129,7 +125,7 @@ function format_stats(value, build, colname) {
     html = value;
     if (build.new_stats && build.new_stats[colname]) {
         html += '&nbsp<a href="' +
-            flaskUrlFor('build', { 'buildid': build._id }).replace('build?buildid=', 'builds/') +
+            Flask.url_for('build', {'buildid': build._id}) +
             '#new_' + colname + '"> (+' + build.new_stats[colname] + ')</a>';
     }
     return html;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Bootstrap-Flask~=2.4
+Flask-JSGlue @ https://github.com/Centers-Health/Flask-JSGlue/tarball/b467d942947548b1076337fd11f17723bf8059ea#sha256=cfa9912e566341e2a42cb1b162ea4796c0975cba6f056144cd8f9fdbf2f88ae9
 Flask-PyMongo~=2.3
 Flask-Script~=2.0
 Flask-SocketIO~=5.4

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,6 +29,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.datatables.net/v/bs5/jq-3.7.0/dt-2.1.7/datatables.min.js"></script>
+    {{JSGlue.include()}}
     <script src="{{ url_for('static', filename='pkgstatus.js') }}"></script>
     <script src="{{ url_for('servers_js') }}" type="text/javascript"></script>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,7 +30,6 @@
     <script src="https://cdn.datatables.net/v/bs5/jq-3.7.0/dt-2.1.7/datatables.min.js"></script>
     {{JSGlue.include()}}
     <script src="{{ url_for('static', filename='pkgstatus.js') }}"></script>
-    <script src="{{ url_for('servers_js') }}" type="text/javascript"></script>
 
     <script>
       var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
@@ -42,4 +41,3 @@
     {% block scripts %}{% endblock %}
 </body>
 </html>
-

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}pkg-status.FreeBSD.org{% endblock %}</title>
 
     <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
 

--- a/templates/build.html
+++ b/templates/build.html
@@ -7,11 +7,11 @@
 
   <div class="d-flex mb-2">
     <div class="font-weight-bold pr-2" style="min-width: 120px;"><strong>Build:</strong></div>
-    <div>{{ pkgstatus.linkbuild(build, servers) }}</div>
+    <div>{{ pkgstatus.linkbuild(build) }}</div>
   </div>
   <div class="d-flex mb-2">
     <div class="font-weight-bold pr-2" style="min-width: 120px;"><strong>Server:</strong></div>
-    <div>{{ pkgstatus.linkserver(build, servers) }}</div>
+    <div>{{ pkgstatus.linkserver(build) }}</div>
   </div>
   <div class="d-flex mb-2">
     <div class="font-weight-bold pr-2" style="min-width: 120px;"><strong>Status:</strong></div>
@@ -19,7 +19,7 @@
   </div>
   <div class="d-flex mb-2">
     <div class="font-weight-bold pr-2" style="min-width: 120px;"><strong>Jail:</strong></div>
-    <div>{{ pkgstatus.linkjail(build, servers) }}</div>
+    <div>{{ pkgstatus.linkjail(build) }}</div>
   </div>
   <div class="d-flex mb-2">
     <div class="font-weight-bold pr-2" style="min-width: 120px;"><strong>Set:</strong></div>
@@ -110,7 +110,7 @@
             {% set reason=ports[stat][origin].errortype %}
             {%- endif %}
             <td data-order="{{ reason }}">
-              {{ pkgstatus.linklog(build, servers, reason, ports.pkgnames[origin]) }}
+              {{ pkgstatus.linklog(build, reason, ports.pkgnames[origin]) }}
             </td>
           {%- endif %}
         </tr>

--- a/templates/builds.html
+++ b/templates/builds.html
@@ -40,36 +40,6 @@ Viewing all matching builds.
       </tr>
     </thead>
     <tbody>
-    {% if false %}
-    {% for build in builds %}
-      <tr id="{{ build._id }}">
-        <td>{{ pkgstatus.linkset(build.setname) }}</td>
-        <td>{{ build.ptname }}</td>
-        <td>{{ pkgstatus.linkjail(build, servers) }}</td>
-        <td>{{ pkgstatus.linkbuild(build, servers) }}</td>
-        <td data-filter="no">{{ build.stats.queued }}</td>
-        {% for stat in ["built", "failed", "skipped", "ignored"] %}
-        <td data-filter="no" data-order="{{ build.stats[stat] }}">{{ build.stats[stat] }}
-          {%- if build.new_stats and build.new_stats[stat] -%}
-          &nbsp;<a
-            href="{{ url_for('build', buildid=build._id) }}#new_{{ stat }}">
-            (+{{ build.new_stats[stat] }})
-          </a>
-          {%- endif -%}
-        </td>
-        {% endfor %}
-        <td data-filter="no">{{ build.stats.remaining }}</td>
-        <td>{{ build.status }}</td>
-        <td data-order="{{ (build.started) }}">
-          {{ (build.started) | datetime }}
-        </td>
-        <td data-order="{{ build.snap.elapsed }}">
-          {{ build.snap.elapsed|duration }}
-        </td>
-        <td>{{ pkgstatus.linkserver(build, servers) }}</td>
-      </tr>
-    {%- endfor -%}
-    {% endif %}
     </tbody>
   </table>
 </div>

--- a/templates/jsglue/js_bridge.js
+++ b/templates/jsglue/js_bridge.js
@@ -1,0 +1,95 @@
+var {{ namespace }} = new(function () {
+  'use strict';
+  return {
+    '_endpoints': {{ rules|safe }},
+    'url_for': function (endpoint, rule) {
+      if (typeof rule === "undefined") rule = {};
+      else if (typeof(rule) !== "object") {
+        // rule *must* be an Object, anything else is wrong
+        throw {name: "ValueError", message: "type for 'rule' must be Object, got: " + typeof(rule)};
+      }
+
+      var has_everything = false,
+        url = "";
+
+      var is_absolute = false,
+        has_anchor = false,
+        has_scheme;
+      var anchor = "",
+        scheme = "";
+
+      if (rule['_external'] === true) {
+        is_absolute = true;
+        scheme = location.protocol.split(':')[0];
+        delete rule['_external'];
+      }
+
+      if ('_scheme' in rule) {
+        if (is_absolute) {
+          scheme = rule['_scheme'];
+          delete rule['_scheme'];
+        } else {
+          throw {
+            name: "ValueError",
+            message: "_scheme is set without _external."
+          };
+        }
+      }
+
+      if ('_anchor' in rule) {
+        has_anchor = true;
+        anchor = rule['_anchor'];
+        delete rule['_anchor'];
+      }
+
+      for (var i in this._endpoints) {
+        if (endpoint == this._endpoints[i][0]) {
+          var url = '';
+          var j = 0;
+          var has_everything = true;
+          var used = {};
+          for (var j = 0; j < this._endpoints[i][2].length; j++) {
+            var t = rule[this._endpoints[i][2][j]];
+            if (typeof t === "undefined") {
+              has_everything = false;
+              break;
+            }
+            url += this._endpoints[i][1][j] + t;
+            used[this._endpoints[i][2][j]] = true;
+          }
+          if (has_everything) {
+            if (this._endpoints[i][2].length != this._endpoints[i][1].length)
+              url += this._endpoints[i][1][j];
+
+            var first = true;
+            for (var r in rule) {
+              if (r[0] != '_' && !(r in used)) {
+                if (first) {
+                  url += '?';
+                  first = false;
+                } else {
+                  url += '&';
+                }
+                url += r + '=' + rule[r];
+              }
+            }
+            if (has_anchor) {
+              url += "#" + anchor;
+            }
+
+            if (is_absolute) {
+              return scheme + "://" + location.host + url;
+            } else {
+              return url;
+            }
+          }
+        }
+      }
+
+      throw {
+        name: 'BuildError',
+        message: "Endpoint '" + endpoint + "' does not exist or you have passed incorrect parameters " + JSON.stringify(rule)
+      };
+    }
+  };
+});

--- a/templates/pkgstatus.html
+++ b/templates/pkgstatus.html
@@ -38,17 +38,17 @@
 {{ setname }}
 {%- endmacro %}
 
-{% macro linkbuild(build, servers) -%}
+{% macro linkbuild(build) -%}
 <a data-bs-toggle="tooltip" title="All builds matching buildname {{ build.buildname }}" href="{{ url_for('builds', buildname=build.buildname) }}">{{ filter_icon() }}</a>
-{{ linkpoudrierebuild(build, servers) }}
-<a data-bs-toggle="tooltip" title="Build {{ build._id }}" href="{{ url_for('build', buildid=build._id) }}">{{ build.buildname }}</a>
+{{ linkpoudrierebuild(build) }}
+<a data-bs-toggle="tooltip" title"Build {{ build._id }}" href="{{ url_for('build', buildid=build._id)}}">{{ build.buildname }}</a>
 {%- endmacro %}
 
 {% macro local_log_base(build) -%}
 /logs/{{ build.server }}/{{ build.mastername }}/{{ build.buildname }}
 {%- endmacro %}
 
-{% macro linkpoudrierebuild(build, servers) -%}
+{% macro linkpoudrierebuild(build) -%}
 <a target="_new" data-bs-toggle="tooltip" title="Poudriere Build"
 {% if build['have_logs'] %}
 href="{{ local_log_base(build) }}"
@@ -58,13 +58,13 @@ href="{{ url_for('poudriere', server=build.server, uri='build.html', mastername=
 >{{ poudriere_icon() }}</a>
 {%- endmacro %}
 
-{% macro linkjail(build, servers) -%}
+{% macro linkjail(build) -%}
 <a data-bs-toggle="tooltip" title="All builds matching jail {{ build.jailname }}" href="{{ url_for('builds', jailname=build.jailname) }}">{{ filter_icon() }}</a>
 <a target="_new" data-bs-toggle="tooltip" title="Poudriere Jail" href="{{ url_for('poudriere', server=build.server, uri='jail.html', mastername=build.mastername) }}">{{ poudriere_icon() }}</a>
 {{ build.jailname }}
 {%- endmacro %}
 
-{% macro linkserver(build, servers) -%}
+{% macro linkserver(build) -%}
 <a data-bs-toggle="tooltip" title="All builds matching server {{ build.server }}" href="{{ url_for('builds', server=build.server) }}">{{ filter_icon() }}</a>
 <a target="_new" data-bs-toggle="tooltip" title="Poudriere Server" href="{{ url_for('poudriere', server=build.server) }}">{{ poudriere_icon() }}</a>
 {{ build.server }}
@@ -75,7 +75,7 @@ href="{{ url_for('poudriere', server=build.server, uri='build.html', mastername=
 {{ build_type|capitalize }}
 {%- endmacro %}
 
-{% macro linklog(build, servers, text, pkgname) -%}
+{% macro linklog(build, text, pkgname) -%}
 <a target="_new" data-bs-toggle="tooltip" title="Build Log for {{ pkgname }}"
 {% if build['have_logs'] %}
   href="{{ local_log_base(build) }}/logs/{{ pkgname }}.log"

--- a/templates/pkgstatus.html
+++ b/templates/pkgstatus.html
@@ -53,20 +53,20 @@
 {% if build['have_logs'] %}
 href="{{ local_log_base(build) }}"
 {% else %}
-href="http://{{ servers[build.server].host }}/build.html?mastername={{ build.mastername }}&amp;build={{ build.buildname }}"
+href="{{ url_for('poudriere', server=build.server, uri='build.html', mastername=build.mastername, build=build.buildname) }}"
 {% endif %}
 >{{ poudriere_icon() }}</a>
 {%- endmacro %}
 
 {% macro linkjail(build, servers) -%}
 <a data-bs-toggle="tooltip" title="All builds matching jail {{ build.jailname }}" href="{{ url_for('builds', jailname=build.jailname) }}">{{ filter_icon() }}</a>
-<a target="_new" data-bs-toggle="tooltip" title="Poudriere Jail" href="http://{{ servers[build.server].host }}/jail.html?mastername={{ build.mastername }}">{{ poudriere_icon() }}</a>
+<a target="_new" data-bs-toggle="tooltip" title="Poudriere Jail" href="{{ url_for('poudriere', server=build.server, uri='jail.html', mastername=build.mastername) }}">{{ poudriere_icon() }}</a>
 {{ build.jailname }}
 {%- endmacro %}
 
 {% macro linkserver(build, servers) -%}
 <a data-bs-toggle="tooltip" title="All builds matching server {{ build.server }}" href="{{ url_for('builds', server=build.server) }}">{{ filter_icon() }}</a>
-<a target="_new" data-bs-toggle="tooltip" title="Poudriere Server" href="http://{{ servers[build.server].host }}/">{{ poudriere_icon() }}</a>
+<a target="_new" data-bs-toggle="tooltip" title="Poudriere Server" href="{{ url_for('poudriere', server=build.server) }}">{{ poudriere_icon() }}</a>
 {{ build.server }}
 {%- endmacro %}
 
@@ -80,7 +80,8 @@ href="http://{{ servers[build.server].host }}/build.html?mastername={{ build.mas
 {% if build['have_logs'] %}
   href="{{ local_log_base(build) }}/logs/{{ pkgname }}.log"
 {% else %}
-  href="http://{{ servers[build.server].host }}/data/{{ build.mastername }}/{{ build.buildname }}/logs/{{ pkgname }}.log"
+  href="{{ url_for('poudriere', server=build.server,
+  uri="data/{}/{}/logs/{}.log".format(build.mastername, build.buildname, pkgname)) }}"
 {% endif %}
 ><span class="bi bi-file-earmark"></span>{{ text }}</a>
 {%- endmacro %}


### PR DESCRIPTION
## Proxy support
- Send all package builder links through /servername/ which will proxy on the official pkg-status.freebsd.org site.
- Support `env PKGSTATUS_PROXY_SERVER` which redirects local links to the env server. For example `PKGSTATUS_PROXY_SERVER=https://pkg-status.freebsd.org`. Useful for other setups and local testing.
- Support the proxy server in gather_to_mongo.py, for remote testing, using `PKGSTATUS_GATHER_PROXY_SERVER=URL`.

## Import JSGlue

- JSGlue is imported for dynamic `url_for` support in javascript.

## Trimming

- Trim builds older than `env PKGSTATUS_GATHER_TRIM_YEARS` years old at import time. No default. 

I added `export PKGSTATUS_GATHER_TRIM_YEARS=3` to the `gather_to_mongod.env` file on pkg-status FreeBSD system. @dbaio you may need to manually copy that to your new server.